### PR TITLE
New resize camera function

### DIFF
--- a/example/boilerplate3d.js
+++ b/example/boilerplate3d.js
@@ -55,10 +55,13 @@ export class Boilerplate3D {
 	
 		//resize
 		window.addEventListener( 'resize', () => {
-			this.camera.aspect = window.innerWidth / window.innerHeight;
+			const aspect = this.container.clientWidth / this.container.clientHeight;
+			const height = this.camera.top - this.camera.bottom;
+			this.camera.left = -0.5 * aspect * height + this.camera.position.x;
+			this.camera.right = 0.5 * aspect * height + this.camera.position.x;
 			this.camera.updateProjectionMatrix();
-			this.renderer.setSize( window.innerWidth, window.innerHeight );
-		}, false );
+			this.renderer.setSize(this.container.clientWidth, this.container.clientHeight);
+		});
 	}
 
 	addDXF( dxf ) {


### PR DESCRIPTION
This update modifies the resize function to ensure the orthographic camera maintains the correct aspect ratio. It addresses issues related to the camera's resizing behavior.

**Changes:**
Modified the resize function to preserve the aspect ratio of the orthographic camera.
Resolved issues associated with incorrect camera behavior during resizing.

**Current behavior:**
[Screencast from 2023-12-20 22-25-43.webm](https://github.com/ieskudero/three-dxf-viewer/assets/35701560/9a5a2e2f-1904-4471-847d-0a0acef1400d)

**After update proposal:**
[Screencast from 2023-12-20 22-21-14.webm](https://github.com/ieskudero/three-dxf-viewer/assets/35701560/0a668e11-1781-4aa8-a9d8-0dddd5ed19d2)
