### PR TITLE
the inserted block's extrusionZ parameter not processed

### DIFF
--- a/src/entities/blockEntity.js
+++ b/src/entities/blockEntity.js
@@ -135,9 +135,6 @@ export class BlockEntity extends BaseEntity {
 					obj3d.position.set( _entity.extrusionZ * _entity.x, _entity.y, _entity.z );
                     
 					group.add( obj3d );
-					if (extrusionZ < 0) {
-						console.log("xxxx", entity, _entity, group, obj3d);
-					}
 				}
 			} break;
 			case 'HATCH': {

--- a/src/entities/blockEntity.js
+++ b/src/entities/blockEntity.js
@@ -124,15 +124,20 @@ export class BlockEntity extends BaseEntity {
 					let sy = _entity.scaleY ? _entity.scaleY : 1;
 					let sz = _entity.scaleZ ? _entity.scaleZ : 1;
                         
-					obj3d.scale.set( sx, sy, sz );
+					_entity.extrusionZ = _entity.extrusionZ < 0 ? -1 : 1;
+
+					obj3d.scale.set( _entity.extrusionZ * sx, sy, sz );
 
 					if ( _entity.rotation ) {
-						obj3d.rotation.z = _entity.rotation * Math.PI / 180;
+						obj3d.rotation.z = _entity.extrusionZ * _entity.rotation * Math.PI / 180;
 					}
                         
-					obj3d.position.set( _entity.x, _entity.y, _entity.z );
+					obj3d.position.set( _entity.extrusionZ * _entity.x, _entity.y, _entity.z );
                     
 					group.add( obj3d );
+					if (extrusionZ < 0) {
+						console.log("xxxx", entity, _entity, group, obj3d);
+					}
 				}
 			} break;
 			case 'HATCH': {

--- a/src/entities/insertEntity.js
+++ b/src/entities/insertEntity.js
@@ -75,7 +75,7 @@ export class InsertEntity extends BaseEntity {
 			const extrusionZ = entity.extrusionZ < 0 ? -1 : 1;
 			group.add( this._blockEntity.drawBlock( block, extrusionZ ) );
 
-			group.scale.set( sx, sy, sz );
+			group.scale.set( extrusionZ * sx, sy, sz );
 
 			if ( entity.rotation ) {
 				group.rotation.z =  extrusionZ * ( entity.rotation * Math.PI / 180.0 );


### PR DESCRIPTION
When the inserted entity's group code (210,220,230) has value(0, 0, -1)， the entity's threejs object will display incorrectly. 

This is the AutoCAD's example file:
[Example.dxf.tar.gz](https://github.com/user-attachments/files/16092159/Example.dxf.tar.gz)

![1](https://github.com/ieskudero/three-dxf-viewer/assets/1401796/29ff5dd3-ded1-4a1b-a29f-98bd3c4000d1)
