### PR TITLE
Fix ESM module loading

### DIFF
--- a/vite.prod.config.js
+++ b/vite.prod.config.js
@@ -13,10 +13,10 @@ export default defineConfig( {
 		lib: {
 			entry: resolve( __dirname, 'main.js' ),
 			name: '[name]',
+			fileName: '[name]',
 		},
 		rollupOptions: {
 			output: {
-				entryFileNames: '[name].js'			//set output file name as main.js
 			}
 		}
 	},


### PR DESCRIPTION
Version 1.0.31 added `type: module` to the package which changed the loading behaviour. In `Vite.prod.config.js` the `entryFIleNames` was set to `main.js` always which means `main.js` (ESM) was overwritten by what would normally be `main.umd.cjs`.

I think this is what was causing issues #13 and #14, the module couldn't load