### PR TITLE
Fix error in Merger

### DIFF
--- a/src/utils/merger.js
+++ b/src/utils/merger.js
@@ -47,7 +47,7 @@ export class Merger {
 				scene.add( line );
 			}
 		} else {
-			if ( mesh ) mesh.add( mesh ); 
+			if ( mesh ) scene.add( mesh ); 
 			if ( line ) scene.add( line ); 
 		}
 


### PR DESCRIPTION
When using merger, threejs throws an error because the same mesh is added as a child of itself. Error message: THREE.Object3D.add: object can't be added as a child of itself.